### PR TITLE
try create `maps/` folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ database.xml
 .vscode/settings.json
 database_cache.json
 id1/
+history.txt

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## Intro
 
-```
+```plain
      .::-           .::.
    .::                 ::.
   :6.                    ::
@@ -36,31 +36,48 @@ As the familiar expression says, `"A Quake map a day keeps boredom away"`.
 ### Linux
 
 Install python 3 if needed:
-```
+
+```bash
 sudo apt-get update
 sudo apt-get install python3
 ```
 
 Install pip3 if needed:
-```
+
+```bash
 sudo apt-get update
 sudo apt install python3-pip
 ```
 
 Install this project requirements:
+
+```bash
+pip3 install -r requirements.txt
 ```
+
+### MacOS
+
+Install python3 using [Brew](https://brew.sh/) (recommended)
+
+```bash
+brew install python3
+```
+
+Install this project requirements:
+
+```bash
 pip3 install -r requirements.txt
 ```
 
 ### Windows
 
-Install python 3 if needed: https://www.python.org/downloads/windows/
+Install python 3 if needed: <https://www.python.org/downloads/windows/>
 
 Install this project requirements:
-```
+
+```powershell
 pip3 install -r requirements.txt
 ```
-
 
 ## Running
 
@@ -68,33 +85,35 @@ Execute from a command line at your Quake root folder.
 
 ### Linux
 
-```
+```bash
 python3 quaddicted-random-map.py
 ```
 
 To select another engine (default is [vkQuake](https://github.com/Novum/vkQuake)), use `--engine` param:
-```
+
+```bash
 python3 quaddicted-random-map.py --engine ./quakespasm
 ```
 
 If you don't have the python file in the same folder as quake, use `--path <...>` param:
-```
-python3 /<somepath>/quaddicted-random-map.py --path ./
+
+```bash
+python3 /<somepath>/quaddicted-random-map.py --path /<someotherpath>/Quake
 ```
 
 ### Windows
 
-```
+```bash
 python quaddicted-random-map.py
 ```
 
 To select another engine (default is [vkQuake](https://github.com/Novum/vkQuake)), use `--engine` param (no need to add `.exe` extension):
-```
+
+```powershell
 python quaddicted-random-map.py --engine quakespasm
 ```
 
 etcetera (see Linux version for other parameters)
-
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ python3 /<somepath>/quaddicted-random-map.py --path /<someotherpath>/Quake
 
 ### Windows
 
-```bash
+```powershell
 python quaddicted-random-map.py
 ```
 

--- a/quaddicted-random-map.py
+++ b/quaddicted-random-map.py
@@ -70,7 +70,7 @@ class Configuration:
 
     @property
     def command_line_binary_and_args(self) -> List[str]:
-        return [self._engine_binary_arg] + self.COMMAND_LINE_ARGS.split(" ")
+        return [self._engine_binary_arg] + self.COMMAND_LINE_ARGS.split(" ") + ["-basedir", self.execution_path]
 
     @property
     def _engine_binary_arg(self) -> str:
@@ -228,10 +228,10 @@ class Database:
             json.dump(self.cache, cache_file_handle, indent=None)
 
     def _lowercase_files(self) -> None:
-        for filename in os.listdir(self.config.QUAKE_MAPS_PATH):
+        for filename in os.listdir(self.config.maps_path):
             os.rename(
-                os.path.join(self.config.QUAKE_MAPS_PATH, filename),
-                os.path.join(self.config.QUAKE_MAPS_PATH, filename.lower()),
+                os.path.join(self.config.maps_path, filename),
+                os.path.join(self.config.maps_path, filename.lower()),
             )
 
 
@@ -305,4 +305,4 @@ if __name__ == "__main__":
 
     input("\n-=[ Press Enter to start Quake with map '{}' ]=-".format(map_filename))
 
-    subprocess.run(config.command_line_binary_and_args + ["+map", map_filename] + ["-basedir", config.execution_path])
+    subprocess.run(config.command_line_binary_and_args + ["+map", map_filename])

--- a/quaddicted-random-map.py
+++ b/quaddicted-random-map.py
@@ -55,8 +55,11 @@ class Configuration:
 
     def check_quake_folder(self) -> None:
         if not os.path.exists(self.maps_path):
-            print("> ERROR can't find Quake maps folder ('{}')".format(self.maps_path))
-            exit(1)
+            try:
+                os.mkdir(self.maps_path)
+            except OSError:
+                print("> ERROR can't find/create Quake maps folder ('{}').".format(self.maps_path))
+                exit(1)
 
     def set_engine_binary(self, engine_binary: str) -> None:
         self.engine_binary = engine_binary.lower()


### PR DESCRIPTION
I tried a fresh installation of Quake, it seems that there is no `map/` forlder inside `id1` by default, so I modified the check a bit to try an create the folder if it doesn't exists. Maybe it should no longer be called check... 🤔 anyway, it works now XD